### PR TITLE
hiLayerResponse and historicalBytes are optional

### DIFF
--- a/lib/src/platform_tags/iso_dep.dart
+++ b/lib/src/platform_tags/iso_dep.dart
@@ -29,10 +29,10 @@ class IsoDep {
   final Uint8List identifier;
 
   /// The value from IsoDep#hiLayerResponse on Android.
-  final Uint8List hiLayerResponse;
+  final Uint8List? hiLayerResponse;
 
   /// The value from IsoDep#historicalBytes on Android.
-  final Uint8List historicalBytes;
+  final Uint8List? historicalBytes;
 
   /// The value from IsoDep#isExtendedLengthApduSupported on Android.
   final bool isExtendedLengthApduSupported;


### PR DESCRIPTION
Those two properties can be null according to: https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/nfc/tech/IsoDep.java;l=120?q=IsoDep.java&ss=android%2Fplatform%2Fsuperproject