### PR TITLE
add setTimeout and getTimeout method to IsoDep

### DIFF
--- a/android/src/main/kotlin/io/flutter/plugins/nfcmanager/NfcManagerPlugin.kt
+++ b/android/src/main/kotlin/io/flutter/plugins/nfcmanager/NfcManagerPlugin.kt
@@ -74,6 +74,8 @@ class NfcManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       "NfcF#transceive" -> handleNfcFTransceive(call, result)
       "NfcV#transceive" -> handleNfcVTransceive(call, result)
       "IsoDep#transceive" -> handleIsoDepTransceive(call, result)
+      "IsoDep#getTimeout" -> handleIsoDepGetTimeout(call, result)
+      "IsoDep#setTimeout" -> handleIsoDepSetTimeout(call, result)
       "MifareClassic#authenticateSectorWithKeyA" -> handleMifareClassicAuthenticateSectorWithKeyA(call, result)
       "MifareClassic#authenticateSectorWithKeyB" -> handleMifareClassicAuthenticateSectorWithKeyB(call, result)
       "MifareClassic#increment" -> handleMifareClassicIncrement(call, result)
@@ -199,6 +201,19 @@ class NfcManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     tagHandler(call, result, { IsoDep.get(it) }) {
       val data = call.argument<ByteArray>("data")!!
       result.success(it.transceive(data))
+    }
+  }
+
+  private fun handleIsoDepGetTimeout(call: MethodCall, result: Result) {
+    tagHandler(call, result, { IsoDep.get(it) }) {
+      result.success(it.timeout)
+    }
+  }
+
+  private fun handleIsoDepSetTimeout(call: MethodCall, result: Result) {
+    tagHandler(call, result, { IsoDep.get(it) }) {
+      it.timeout = call.argument<Int>("time")!!
+      result.success(it.timeout)
     }
   }
 

--- a/lib/src/platform_tags/iso_dep.dart
+++ b/lib/src/platform_tags/iso_dep.dart
@@ -19,7 +19,7 @@ class IsoDep {
     required this.historicalBytes,
     required this.isExtendedLengthApduSupported,
     required this.maxTransceiveLength,
-    required this.timeout,
+    required this.initialTimeout,
   }) : _tag = tag;
 
   // _tag
@@ -40,8 +40,8 @@ class IsoDep {
   /// The value from IsoDep#maxTransceiveLength on Android.
   final int maxTransceiveLength;
 
-  /// The value from IsoDep#timeout on Android.
-  final int timeout;
+  /// The value from IsoDep#timeout on Android in initialize.
+  final int initialTimeout;
 
   /// Get an instance of `IsoDep` for the given tag.
   ///
@@ -57,6 +57,23 @@ class IsoDep {
     return channel.invokeMethod('IsoDep#transceive', {
       'handle': _tag.handle,
       'data': data,
+    }).then((value) => value!);
+  }
+
+  /// This uses IsoDep#setTimeout API on Android.
+  Future<int> setTimeout({
+    required int time,
+  }) async {
+    return channel.invokeMethod('IsoDep#setTimeout', {
+      'handle': _tag.handle,
+      'time': time,
+    }).then((value) => value!);
+  }
+
+  /// This uses IsoDep#getTimeout API on Android.
+  Future<int> getTimeout() async {
+    return channel.invokeMethod('IsoDep#getTimeout', {
+      'handle': _tag.handle,
     }).then((value) => value!);
   }
 }

--- a/lib/src/translator.dart
+++ b/lib/src/translator.dart
@@ -296,7 +296,7 @@ IsoDep? $GetIsoDep(NfcTag arg) {
     historicalBytes: data['historicalBytes'],
     isExtendedLengthApduSupported: data['isExtendedLengthApduSupported'],
     maxTransceiveLength: data['maxTransceiveLength'],
-    timeout: data['timeout'],
+    initialTimeout: data['timeout'],
   );
 }
 


### PR DESCRIPTION
- Added two methods to the IsoDep class. 
  - One is setTimeout and the second is getTimeout.
  - It uses Android's IsoDep [setTimeout](https://developer.android.com/reference/android/nfc/tech/IsoDep#setTimeout(int)) and [getTimeout](https://developer.android.com/reference/android/nfc/tech/IsoDep#getTimeout()) respectively.

- Changed the existing member variable `timeout` to `initialTimeout`.

### Confirmation
```
NfcManager.instance.startSession(onDiscovered: (NfcTag tag) async {
      result.value = tag.data;
      var isoDep = IsoDep.from(tag);
      if (isoDep != null) {
        print("initialTimeout ${isoDep.initialTimeout}");
        var time = await isoDep.setTimeout(time: 60000000);
        print("setTimeout setTimeout $time}");
        var getTime = await isoDep.getTimeout();
        print("getTime $getTime}");
      }
      NfcManager.instance.stopSession();
    });
```

