### PR TITLE
Link CoreNFC weakly

### DIFF
--- a/ios/nfc_manager.podspec
+++ b/ios/nfc_manager.podspec
@@ -15,6 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
+  s.weak_frameworks = ['CoreNFC']
   s.platform = :ios, '8.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
To prevent apps using this library from crashing on iPhone 6, link CoreNFC as a weak framework.