### PR TITLE
Return ISO15693 response error code

### DIFF
--- a/ios/Classes/Translator.swift
+++ b/ios/Classes/Translator.swift
@@ -157,5 +157,10 @@ func getErrorMap(_ arg: Error) -> [String : Any?] {
 }
 
 func getFlutterError(_ arg: Error) -> FlutterError {
-  return FlutterError(code: "\((arg as NSError).code)", message:arg.localizedDescription, details: nil)
+  let error = arg as NSError;
+  if let isoError = error.userInfo[NFCISO15693TagResponseErrorKey] {
+      return FlutterError(code: "\(isoError)", message:error.localizedDescription, details: nil);
+  } else {
+      return FlutterError(code: "\(error.code)", message:error.localizedDescription, details: nil);
+  }
 }


### PR DESCRIPTION
After some investigation the error code that was being sent wasn't the actual code received. As per apple documentation the code can be found in error.userInfo[NFCISO15693TagResponseErrorKey] 