### PR TITLE
Added if NFC is supported method

### DIFF
--- a/android/src/main/kotlin/io/flutter/plugins/nfcmanager/NfcManagerPlugin.kt
+++ b/android/src/main/kotlin/io/flutter/plugins/nfcmanager/NfcManagerPlugin.kt
@@ -63,6 +63,7 @@ class NfcManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   override fun onMethodCall(call: MethodCall, result: Result) {
     when (call.method) {
       "Nfc#isAvailable" -> handleNfcIsAvailable(call, result)
+      "Nfc#isSupported" -> handleNfcIsSupported(call, result)
       "Nfc#startSession" -> handleNfcStartSession(call, result)
       "Nfc#stopSession" -> handleNfcStopSession(call, result)
       "Nfc#disposeTag" -> handleNfcDisposeTag(call, result)
@@ -94,6 +95,10 @@ class NfcManagerPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
 
   private fun handleNfcIsAvailable(call: MethodCall, result: Result) {
     result.success(adapter?.isEnabled == true)
+  }
+
+  private fun handleNfcIsSupported(call: MethodCall, result: Result) {
+    result.success(this.adapter != null)
   }
 
   private fun handleNfcStartSession(call: MethodCall, result: Result) {

--- a/lib/src/nfc_manager/nfc_manager.dart
+++ b/lib/src/nfc_manager/nfc_manager.dart
@@ -30,6 +30,10 @@ class NfcManager {
     return channel.invokeMethod('Nfc#isAvailable').then((value) => value!);
   }
 
+  /// Checks whether the NFC features are supported in the hardware level
+  Future<bool> isSupported() async {
+    return channel.invokeMethod('Nfc#isSupported').then((value) => value!);
+  }
   /// Start the session and register callbacks for tag discovery.
   ///
   /// This uses the NFCTagReaderSession (on iOS) or NfcAdapter#enableReaderMode (on Android).


### PR DESCRIPTION
Sometimes, App needs to know if the device is supporting NFC So that it will disable some of the functionalities beforehand related to the NFC.  I added a simple boolean method to achieve this.