### PR TITLE
Added restartPolling on iOS to be able to keep polling for multiple NFC tags after detecting one.

### DIFF
--- a/ios/Classes/SwiftNfcManagerPlugin.swift
+++ b/ios/Classes/SwiftNfcManagerPlugin.swift
@@ -751,7 +751,6 @@ extension SwiftNfcManagerPlugin: NFCTagReaderSessionDelegate {
       if let error = error {
         // skip tag detection
         print(error)
-        self.channel.invokeMethod("onError", arguments: getErrorMap(error))
         if !self.shouldInvalidateSessionAfterFirstRead { session.restartPolling() }
         return
       }
@@ -760,7 +759,6 @@ extension SwiftNfcManagerPlugin: NFCTagReaderSessionDelegate {
         if let error = error {
           // skip tag detection
           print(error)
-          self.channel.invokeMethod("onError", arguments: getErrorMap(error))
           if !self.shouldInvalidateSessionAfterFirstRead { session.restartPolling() }
           return
         }

--- a/ios/Classes/SwiftNfcManagerPlugin.swift
+++ b/ios/Classes/SwiftNfcManagerPlugin.swift
@@ -748,6 +748,7 @@ extension SwiftNfcManagerPlugin: NFCTagReaderSessionDelegate {
       if let error = error {
         // skip tag detection
         print(error)
+        session.restartPolling()
         return
       }
 
@@ -755,13 +756,14 @@ extension SwiftNfcManagerPlugin: NFCTagReaderSessionDelegate {
         if let error = error {
           // skip tag detection
           print(error)
+          session.restartPolling()
           return
         }
 
         self.tags[handle] = tag
         self.channel.invokeMethod("onDiscovered", arguments: data.merging(["handle": handle]) { cur, _ in cur })
+        session.restartPolling()
       }
     }
   }
 }
-

--- a/ios/Classes/SwiftNfcManagerPlugin.swift
+++ b/ios/Classes/SwiftNfcManagerPlugin.swift
@@ -751,6 +751,7 @@ extension SwiftNfcManagerPlugin: NFCTagReaderSessionDelegate {
       if let error = error {
         // skip tag detection
         print(error)
+        self.channel.invokeMethod("onError", arguments: getErrorMap(error))
         if !self.shouldInvalidateSessionAfterFirstRead { session.restartPolling() }
         return
       }
@@ -759,6 +760,7 @@ extension SwiftNfcManagerPlugin: NFCTagReaderSessionDelegate {
         if let error = error {
           // skip tag detection
           print(error)
+          self.channel.invokeMethod("onError", arguments: getErrorMap(error))
           if !self.shouldInvalidateSessionAfterFirstRead { session.restartPolling() }
           return
         }

--- a/lib/src/nfc_manager/nfc_manager.dart
+++ b/lib/src/nfc_manager/nfc_manager.dart
@@ -41,11 +41,15 @@ class NfcManager {
   ///
   /// (iOS only) `alertMessage` is used to display the message on the popup shown when the session is started.
   ///
+  /// (iOS only) `invalidateAfterFirstRead` is used to specify whether the session should be invalidated 
+  /// after the first tag is discovered. Default is true.
+  ///
   /// (iOS only) `onError` is called when the session is stopped for some reason after the session has started.
   Future<void> startSession({
     required NfcTagCallback onDiscovered,
     Set<NfcPollingOption>? pollingOptions,
     String? alertMessage,
+    bool? invalidateAfterFirstRead = true,
     NfcErrorCallback? onError,
   }) async {
     _onDiscovered = onDiscovered;
@@ -55,6 +59,7 @@ class NfcManager {
       'pollingOptions':
           pollingOptions.map((e) => $NfcPollingOptionTable[e]).toList(),
       'alertMessage': alertMessage,
+      'invalidateAfterFirstRead': invalidateAfterFirstRead,
     });
   }
 


### PR DESCRIPTION
### Summary
Finding multiple NFC tags on iOS is pretty clunky business, one would have to show the scan modal multiple times which does not lead to a good user experience. NFCTagReaderSession does however have the option to restart polling after finding a tag, thus making it possible to scan more than one NFC tag per session.

I did add the variable `shouldInvalidateAfterFirstRead` so the library user can specify if they want this enabled, default behaviour is disabled and it is optional so we won't disturb any existing uses. The name `shouldInvalidateAfterFirstRead` is based on a similar function in [NFCNDEFReaderSession](https://developer.apple.com/documentation/corenfc/nfcndefreadersession).

### How to test
In the example change `_tagRead` to the following:
``` 
 void _tagRead() {
    NfcManager.instance.startSession(invalidateAfterFirstRead: false, onDiscovered: (NfcTag tag) async {
      result.value = tag.data;
      // NfcManager.instance.stopSession();
    });
  }
```
After this you can spin up the example iOS app and test the scanning of multiple items on one request.