### PR TITLE
Fix crashes in older iphones with no nfc

### DIFF
--- a/ios/nfc_manager.podspec
+++ b/ios/nfc_manager.podspec
@@ -15,6 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
+  s.weak_frameworks = ['CoreNFC']
   s.platform = :ios, '9.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
https://github.com/okadan/flutter-nfc-manager/commit/7a5daa6a35991620d16c3171dbb7690ba92616c8#r88396339