### PR TITLE
update alertMessage

### DIFF
--- a/ios/Classes/SwiftNfcManagerPlugin.swift
+++ b/ios/Classes/SwiftNfcManagerPlugin.swift
@@ -43,6 +43,7 @@ public class SwiftNfcManagerPlugin: NSObject, FlutterPlugin {
     case "Nfc#disposeTag": handleNfcDisposeTag(call.arguments as! [String : Any?], result: result)
     case "Ndef#read": handleNdefRead(call.arguments as! [String : Any?], result: result)
     case "Ndef#write": handleNdefWrite(call.arguments as! [String : Any?], result: result)
+    case "Nfc#updateSession": handleNfcUpdateSession(call.arguments as! [String : Any?], result: result)
     case "Ndef#writeLock": handleNdefWriteLock(call.arguments as! [String : Any?], result: result)
     case "FeliCa#polling": handleFeliCaPolling(call.arguments as! [String : Any?], result: result)
     case "FeliCa#requestResponse": handleFeliCaRequestResponse(call.arguments as! [String : Any?], result: result)
@@ -146,6 +147,12 @@ public class SwiftNfcManagerPlugin: NSObject, FlutterPlugin {
         }
       }
     }
+  }
+
+  @available(iOS 13.0, *)
+  private func handleNfcUpdateSession(_ arguments: [String : Any?], result: @escaping FlutterResult) {
+    if let alertMessage = arguments["alertMessage"] as? String { session?.alertMessage = alertMessage }
+    result(nil)
   }
 
   @available(iOS 13.0, *)

--- a/lib/src/nfc_manager/nfc_manager.dart
+++ b/lib/src/nfc_manager/nfc_manager.dart
@@ -30,6 +30,13 @@ class NfcManager {
     return channel.invokeMethod('Nfc#isAvailable').then((value) => value!);
   }
 
+  /// Update iOS default bottomSheet's alertMessage
+  Future<void> updateSession(String alertMessage) async {
+    return channel.invokeMethod('Nfc#updateSession', {
+      'alertMessage': alertMessage,
+    });
+  }
+
   /// Start the session and register callbacks for tag discovery.
   ///
   /// This uses the NFCTagReaderSession (on iOS) or NfcAdapter#enableReaderMode (on Android).
@@ -41,7 +48,7 @@ class NfcManager {
   ///
   /// (iOS only) `alertMessage` is used to display the message on the popup shown when the session is started.
   ///
-  /// (iOS only) `invalidateAfterFirstRead` is used to specify whether the session should be invalidated 
+  /// (iOS only) `invalidateAfterFirstRead` is used to specify whether the session should be invalidated
   /// after the first tag is discovered. Default is true.
   ///
   /// (iOS only) `onError` is called when the session is stopped for some reason after the session has started.


### PR DESCRIPTION
I've made modifications to update the `alertMessage` property of the iOS default bottomSheet in Flutter. In the given code snippet, we have a method `handleNfcUpdateSession` that takes an argument `alertMessage` and updates the session's `alertMessage` property with the new value. This allows us to dynamically change the alert message displayed in the bottomSheet. Additionally, I've created a Flutter method `updateSession` that you can call to update the `alertMessage` by invoking the native method `Nfc#updateSession` with the new `alertMessage` value.
These changes enable you to provide a customized alert message for the iOS bottomSheet within your Flutter app.