### PR TITLE
fix: make compatible with Kotlin 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.5.1
+
+* Make compatible for Kotlin 2.1.0
+
 # 3.5.0
 
 * Upgrade Flutter.

--- a/android/src/main/kotlin/io/flutter/plugins/nfcmanager/Translator.kt
+++ b/android/src/main/kotlin/io/flutter/plugins/nfcmanager/Translator.kt
@@ -40,7 +40,7 @@ fun getTagMap(arg: Tag): Map<String, Any?> {
 
   arg.techList.forEach { tech ->
     // normalize tech string (e.g. "android.nfc.tech.NfcA" => "nfca"
-    data[tech.toLowerCase(Locale.ROOT).split(".").last()] = when (tech) {
+    data[tech.lowercase(Locale.ROOT).split(".").last()] = when (tech) {
       NfcA::class.java.name -> NfcA.get(arg).let {
         mapOf(
           "identifier" to arg.id,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nfc_manager
 description: Flutter plugin for accessing the NFC features on Android and iOS.
-version: 3.5.0
+version: 3.5.1
 homepage: https://github.com/okadan/flutter-nfc-manager
 
 environment:


### PR DESCRIPTION
String.toLowerCase(locale: Locale) is deprecated. Use lowercase() instead.

It is a warning since 1.5 and an error since 2.1

The minimum Kotlin version is `1.6.10` as introduced in #83 and the `lowercase()` function is there since Kotlin 1.5, so no problem.