### PR TITLE
fix: improve TagPigeon export to support ISO 14443 NFC tags on Android

### DIFF
--- a/packages/nfc_manager/lib/nfc_manager.dart
+++ b/packages/nfc_manager/lib/nfc_manager.dart
@@ -1,1 +1,2 @@
 export 'src/nfc_manager/nfc_manager.dart';
+export 'src/nfc_manager_android/pigeon.g.dart';


### PR DESCRIPTION
I encountered an issue while working with NFC cards that are not NDEF compatible but follow the ISO 14443 standard. When trying to read data from such tags using the `nfc_manager` package on Android, the output was `"instance of TagPigeon"` instead of the actual tag data.

To fix this, I exported `pigeon.g.dart` properly to enable direct access to the tag's low-level data, allowing correct handling and parsing of ISO 14443 tags.

This change improves compatibility with a wider range of NFC tags that are commonly used but not NDEF formatted.

For example, to get the tag ID, you can now do:

```dart

_id = (tag.data as TagPigeon).id.toString();