### PR TITLE
[iOS][FIX] resend to Flutter all tags, even if there's no NDEF data written

### DIFF
--- a/packages/nfc_manager/ios/Classes/NfcManagerPlugin.swift
+++ b/packages/nfc_manager/ios/Classes/NfcManagerPlugin.swift
@@ -492,7 +492,7 @@ private func convert(_ value: NFCNDEFTag, _ completionHandler: @escaping (TagPig
 
   value.queryNDEFStatus { status, capacity, error in
     if let error = error {
-      completionHandler(nil, error)
+      completionHandler(pigeon, nil)
       return
     }
     pigeon.ndef = NdefPigeon(
@@ -505,7 +505,7 @@ private func convert(_ value: NFCNDEFTag, _ completionHandler: @escaping (TagPig
     }
     value.readNDEF { message, error in
       if let error = error {
-        completionHandler(nil, error)
+        completionHandler(pigeon, nil)
         return
       }
       if let message = message {


### PR DESCRIPTION
PR related to issue #244

I fixed the regression by forcing native code to send data to Flutter no matter what, even if there's no NDEF data inside of them