### PR TITLE
fix: error on registering plugin - #252 

### DIFF
--- a/android/src/main/kotlin/dev/flutter/plugins/nfcmanager/NfcManagerPlugin.kt
+++ b/android/src/main/kotlin/dev/flutter/plugins/nfcmanager/NfcManagerPlugin.kt
@@ -6,6 +6,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Context.RECEIVER_NOT_EXPORTED
 import android.content.Intent
+import android.content.IntentFilter
 import android.nfc.NdefMessage
 import android.nfc.NdefRecord
 import android.nfc.NfcAdapter

--- a/android/src/main/kotlin/dev/flutter/plugins/nfcmanager/NfcManagerPlugin.kt
+++ b/android/src/main/kotlin/dev/flutter/plugins/nfcmanager/NfcManagerPlugin.kt
@@ -46,7 +46,7 @@ class NfcManagerPlugin: FlutterPlugin, ActivityAware, HostApiPigeon, BroadcastRe
   }
 
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-    activity = binding.activity ?? return 
+    activity = binding.activity ?: return 
 
     val filter = IntentFilter().apply { 
       addAction(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED)

--- a/android/src/main/kotlin/dev/flutter/plugins/nfcmanager/NfcManagerPlugin.kt
+++ b/android/src/main/kotlin/dev/flutter/plugins/nfcmanager/NfcManagerPlugin.kt
@@ -45,11 +45,16 @@ class NfcManagerPlugin: FlutterPlugin, ActivityAware, HostApiPigeon, BroadcastRe
   }
 
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-    activity = binding.activity
+    activity = binding.activity ?? return 
+
+    val filter = IntentFilter().apply { 
+      addAction(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED)
+    }
+
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      activity.applicationContext.registerReceiver(this, null, RECEIVER_NOT_EXPORTED)
+      activity.applicationContext.registerReceiver(this, filter, RECEIVER_NOT_EXPORTED)
     } else {
-      activity.applicationContext.registerReceiver(this, null)
+      activity.applicationContext.registerReceiver(this, filter)
     }
   }
 


### PR DESCRIPTION
This fix solves the follow problem:

```
E/GeneratedPluginRegistrant( 3936): Error registering plugin nfc_manager, dev.flutter.plugins.nfcmanager.NfcManagerPlugin
E/GeneratedPluginRegistrant( 3936): java.lang.NullPointerException: Attempt to invoke virtual method 'java.util.Iterator android.content.IntentFilter.actionsIterator()' on a null object reference
E/GeneratedPluginRegistrant( 3936):  at android.os.Parcel.createExceptionOrNull(Parcel.java:3248)
E/GeneratedPluginRegistrant( 3936):  at android.os.Parcel.createException(Parcel.java:3226)
E/GeneratedPluginRegistrant( 3936):  at android.os.Parcel.readException(Parcel.java:3209)
E/GeneratedPluginRegistrant( 3936):  at android.os.Parcel.readException(Parcel.java:3151)
E/GeneratedPluginRegistrant( 3936):  at android.app.IActivityManager$Stub$Proxy.registerReceiverWithFeature(IActivityManager.java:6092)
E/GeneratedPluginRegistrant( 3936):  at android.app.ContextImpl.registerReceiverInternal(ContextImpl.java:1881)
E/GeneratedPluginRegistrant( 3936):  at android.app.ContextImpl.registerReceiver(ContextImpl.java:1828)
E/GeneratedPluginRegistrant( 3936):  at android.app.ContextImpl.registerReceiver(ContextImpl.java:1815)
E/GeneratedPluginRegistrant( 3936):  at android.content.ContextWrapper.registerReceiver(ContextWrapper.java:763)
E/GeneratedPluginRegistrant( 3936):  at dev.flutter.plugins.nfcmanager.NfcManagerPlugin.onAttachedToActivity(NfcManagerPlugin.kt:50)
E/GeneratedPluginRegistrant( 3936):  at io.flutter.embedding.engine.FlutterEngineConnectionRegistry.add(FlutterEngineConnectionRegistry.java:157)
E/GeneratedPluginRegistrant( 3936):  at io.flutter.plugins.GeneratedPluginRegistrant.registerWith(GeneratedPluginRegistrant.java:139)
E/GeneratedPluginRegistrant( 3936):  at java.lang.reflect.Method.invoke(Native Method)
E/GeneratedPluginRegistrant( 3936):  at io.flutter.embedding.engine.plugins.util.GeneratedPluginRegister.registerGeneratedPlugins(GeneratedPluginRegister.java:80)
E/GeneratedPluginRegistrant( 3936):  at io.flutter.embedding.android.FlutterFragmentActivity.configureFlutterEngine(FlutterFragmentActivity.java:742)
E/GeneratedPluginRegistrant( 3936):  at br.com.senior.employee.MainActivity.configureFlutterEngine(MainActivity.kt:10)
E/GeneratedPluginRegistrant( 3936):  at io.flutter.embedding.android.FlutterFragment.configureFlutterEngine(FlutterFragment.java:1535)
E/GeneratedPluginRegistrant( 3936):  at io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.onAttach(FlutterActivityAndFragmentDelegate.java:220)
E/GeneratedPluginRegistrant( 3936):  at io.flutter.embedding.android.FlutterFragment.onAttach(FlutterFragment.java:1057)
E/GeneratedPluginRegistrant( 3936):  at androidx.fragment.app.Fragment.performAttach(Fragment.java:3075)
E/GeneratedPluginRegistrant( 3936):  at androidx.fragment.app.FragmentStateManager.attach(FragmentStateManager.java:510)
E/GeneratedPluginRegistrant( 3936):  at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:279)
E/GeneratedPluginRegistrant( 3936):  at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2214)
E/GeneratedPluginRegistrant( 3936):  at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:2109)
E/GeneratedPluginRegistrant( 3936):  at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:2052)
E/GeneratedPluginRegistrant( 3936):  at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:3327)
E/GeneratedPluginRegistrant( 3936):  at androidx.fragment.app.FragmentManager.dispatchActivityCreated(FragmentManager.java:3237)
E/GeneratedPluginRegistrant( 3936):  at androidx.fragment.app.FragmentController.dispatchActivityCreated(FragmentController.java:263)
E/GeneratedPluginRegistrant( 3936):  at androidx.fragment.app.FragmentActivity.onStart(FragmentActivity.java:350)
E/GeneratedPluginRegistrant( 3936):  at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1701)
E/GeneratedPluginRegistrant( 3936):  at android.app.Activity.performStart(Activity.java:9045)
E/GeneratedPluginRegistrant( 3936):  at android.app.ActivityThread.handleStartActivity(ActivityThread.java:4073)
E/GeneratedPluginRegistrant( 3936):  at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:270)
E/GeneratedPluginRegistrant( 3936):  at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:250)
E/GeneratedPluginRegistrant( 3936):  at android.app.servertransaction.TransactionExecutor.executeLifecycleItem(TransactionExecutor.java:222)
E/GeneratedPluginRegistrant( 3936):  at android.app.servertransaction.TransactionExecutor.executeTransactionItems(TransactionExecutor.java:107)
E/GeneratedPluginRegistrant( 3936):  at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:81)
E/GeneratedPluginRegistrant( 3936):  at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2636)
E/GeneratedPluginRegistrant( 3936):  at android.os.Handler.dispatchMessage(Handler.java:107)
E/GeneratedPluginRegistrant( 3936):  at android.os.Looper.loopOnce(Looper.java:232)
E/GeneratedPluginRegistrant( 3936):  at android.os.Looper.loop(Looper.java:317)
E/GeneratedPluginRegistrant( 3936):  at android.app.ActivityThread.main(ActivityThread.java:8705)
E/GeneratedPluginRegistrant( 3936):  at java.lang.reflect.Method.invoke(Native Method)
E/GeneratedPluginRegistrant( 3936):  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
E/GeneratedPluginRegistrant( 3936):  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886)
```

My flutter doctor summary:

```
[√] Flutter (Channel stable, 3.32.8, on Microsoft Windows [versÆo 10.0.26100.7171], locale pt-BR) [768ms]
    • Flutter version 3.32.8 on channel stable at C:\Users\lucas.floriano\fvm\versions\3.32.8
    • Upstream repository https://github.com/flutter/flutter.git
    • Framework revision edada7c56e (4 months ago), 2025-07-25 14:08:03 +0000
    • Engine revision ef0cd00091
    • Dart version 3.8.1
    • DevTools version 2.45.1

[√] Windows Version (11 Pro 64-bit, 24H2, 2009) [3,6s]

[√] Android toolchain - develop for Android devices (Android SDK version 36.0.0) [5,2s]
    • Android SDK at C:\Users\lucas.floriano\AppData\Local\Android\Sdk
    • Platform android-36, build-tools 36.0.0
    • ANDROID_HOME = C:\Users\lucas.floriano\AppData\Local\Android\Sdk
    • Java binary at: C:\Program Files\Java\jdk-21\bin\java
      This JDK is specified in your Flutter configuration.
      To change the current JDK, run: `flutter config --jdk-dir="path/to/jdk"`.
    • Java version Java(TM) SE Runtime Environment (build 21.0.6+8-LTS-188)
    • All Android licenses accepted.

[√] Chrome - develop for the web [34ms]
    • Chrome at C:\Program Files\Google\Chrome\Application\chrome.exe

[X] Visual Studio - develop Windows apps [32ms]
    X Visual Studio not installed; this is necessary to develop Windows apps.
      Download at https://visualstudio.microsoft.com/downloads/.
      Please install the "Desktop development with C++" workload, including all of its default components

[√] Android Studio (version 2024.3) [29ms]
    • Android Studio at C:\Program Files\Android\Android Studio
    • Flutter plugin can be installed from:
       https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
       https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 21.0.5+-12932927-b750.29)

[√] VS Code, 64-bit edition (version 1.106.3) [26ms]
    • VS Code at C:\Program Files\Microsoft VS Code
    • Flutter extension version 3.124.0

[√] Connected device (4 available) [908ms]
    • sdk gphone64 x86 64 (mobile) • emulator-5554 • android-x64    • Android 16 (API 36) (emulator)
    • Windows (desktop)            • windows       • windows-x64    • Microsoft Windows [versÆo 10.0.26100.7171]
    • Chrome (web)                 • chrome        • web-javascript • Google Chrome 142.0.7444.176
    • Edge (web)                   • edge          • web-javascript • Microsoft Edge 141.0.3537.57

[√] Network resources [1.390ms]
    • All expected network resources are available.

! Doctor found issues in 1 category.
```