### PR TITLE
Fix ';' error for android.

### DIFF
--- a/android/src/main/kotlin/dev/flutter/plugins/nfcmanager/NfcManagerPlugin.kt
+++ b/android/src/main/kotlin/dev/flutter/plugins/nfcmanager/NfcManagerPlugin.kt
@@ -6,6 +6,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Context.RECEIVER_NOT_EXPORTED
 import android.content.Intent
+import android.content.IntentFilter
 import android.nfc.NdefMessage
 import android.nfc.NdefRecord
 import android.nfc.NfcAdapter
@@ -46,10 +47,16 @@ class NfcManagerPlugin: FlutterPlugin, ActivityAware, HostApiPigeon, BroadcastRe
 
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
     activity = binding.activity
+    if (activity == null) { return }
+
+    val filter = IntentFilter().apply { 
+      addAction(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED)
+    }
+
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      activity.applicationContext.registerReceiver(this, null, RECEIVER_NOT_EXPORTED)
+      activity.applicationContext.registerReceiver(this, filter, RECEIVER_NOT_EXPORTED)
     } else {
-      activity.applicationContext.registerReceiver(this, null)
+      activity.applicationContext.registerReceiver(this, filter)
     }
   }
 


### PR DESCRIPTION
Updated NFC manager plugin to register a receiver for NFC adapter state changes. This PR is an extension of one noted in issue https://github.com/okadan/flutter-nfc-manager/issues/252 and is based on the PR https://github.com/okadan/flutter-nfc-manager/pull/260